### PR TITLE
Fix schema descriptor (added optional output file)

### DIFF
--- a/cbrain_task_descriptors/PsomWorker.json
+++ b/cbrain_task_descriptors/PsomWorker.json
@@ -36,5 +36,12 @@
     "suggested-resources": {
         "walltime-estimate": 10799
     },
-    "output-files": []
+    "output-files": [
+       {
+          "id": "output_log",
+          "name": "Output log",
+          "path-template": "output.log",
+          "optional": true
+       }
+    ]
 }


### PR DESCRIPTION
In order to be compliant to Boutiques schema 0.5.12, I had to add an optional output-files.